### PR TITLE
remove flakiness from scale test

### DIFF
--- a/tests/system-test-kind.sh
+++ b/tests/system-test-kind.sh
@@ -103,7 +103,18 @@ for i in {1..15}; do
   sleep 8
 done
 
-requests=3000
+echo "Patching stapi deployment to sleep on startup"
+cat <<EOF | kubectl patch deployment stapi-minilm-l6-v2 --type merge --patch "$(cat)"
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: sleep
+        image: busybox
+        command: ["sh", "-c", "sleep 10"]
+EOF
+
+requests=300
 echo "Send $requests requests in parallel to stapi backend using openai python client and threading"
 python3 $SCRIPT_DIR/test_openai_embedding.py \
   --requests $requests --timeout 600 --base-url "${BASE_URL}" \

--- a/tests/system-test-kind.sh
+++ b/tests/system-test-kind.sh
@@ -103,7 +103,7 @@ for i in {1..15}; do
   sleep 8
 done
 
-requests=2000
+requests=3000
 echo "Send $requests requests in parallel to stapi backend using openai python client and threading"
 python3 $SCRIPT_DIR/test_openai_embedding.py \
   --requests $requests --timeout 600 --base-url "${BASE_URL}" \

--- a/tests/system-test-kind.sh
+++ b/tests/system-test-kind.sh
@@ -103,7 +103,7 @@ for i in {1..15}; do
   sleep 8
 done
 
-requests=1000
+requests=2000
 echo "Send $requests requests in parallel to stapi backend using openai python client and threading"
 python3 $SCRIPT_DIR/test_openai_embedding.py \
   --requests $requests --timeout 600 --base-url "${BASE_URL}" \

--- a/tests/system-test-kind.sh
+++ b/tests/system-test-kind.sh
@@ -103,7 +103,7 @@ for i in {1..15}; do
   sleep 8
 done
 
-requests=500
+requests=1000
 echo "Send $requests requests in parallel to stapi backend using openai python client and threading"
 python3 $SCRIPT_DIR/test_openai_embedding.py \
   --requests $requests --timeout 600 --base-url "${BASE_URL}" \


### PR DESCRIPTION
This will reduce flakiness of the system tests. Ocasionally the system test won't scale to 3 replicas because it's too fast at processing 500 requests.

So instead the deployment is patched to wait for 10 seconds before starting the main container. This causes the queue to be build up large enough and cause it to scale up to 3 replicas.