### PR TITLE
Add liveness, readiness probes to example deployment

### DIFF
--- a/deploy/lingo_deploy.yaml
+++ b/deploy/lingo_deploy.yaml
@@ -24,3 +24,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20


### PR DESCRIPTION
Resolves #5 

This may not be the intended solution but tcp probes work well, too