### PR TITLE
Spike: Add optional retry middleware

### DIFF
--- a/cmd/lingo/main.go
+++ b/cmd/lingo/main.go
@@ -119,11 +119,10 @@ func run() error {
 	metricsRegistry := prometheus.WrapRegistererWithPrefix("lingo_", metrics.Registry)
 	queue.NewMetricsCollector(queueManager).MustRegister(metricsRegistry)
 
-	endpointManager, err := endpoints.NewManager(mgr)
+	endpointManager, err := endpoints.NewManager(mgr, queueManager.UpdateQueueSizeForReplicas)
 	if err != nil {
 		return fmt.Errorf("setting up endpoint manager: %w", err)
 	}
-	endpointManager.EndpointSizeCallback = queueManager.UpdateQueueSizeForReplicas
 	// The autoscaling leader will scrape other lingo instances.
 	// Exclude this instance from being scraped by itself.
 	endpointManager.ExcludePods[hostname] = struct{}{}

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -18,8 +18,7 @@ func newEndpointGroup() *endpointGroup {
 }
 
 type endpoint struct {
-	inFlight   *atomic.Int64
-	terminated chan struct{}
+	inFlight *atomic.Int64
 }
 
 type endpointGroup struct {
@@ -107,13 +106,12 @@ func (g *endpointGroup) setIPs(ips map[string]struct{}, ports map[string]int32) 
 	g.ports = ports
 	for ip := range ips {
 		if _, ok := g.endpoints[ip]; !ok {
-			g.endpoints[ip] = endpoint{inFlight: &atomic.Int64{}, terminated: make(chan struct{})}
+			g.endpoints[ip] = endpoint{inFlight: &atomic.Int64{}}
 		}
 	}
-	for ip, endpoint := range g.endpoints {
+	for ip := range g.endpoints {
 		if _, ok := ips[ip]; !ok {
 			delete(g.endpoints, ip)
-			close(endpoint.terminated)
 		}
 	}
 	g.mtx.Unlock()

--- a/pkg/endpoints/manager.go
+++ b/pkg/endpoints/manager.go
@@ -127,8 +127,6 @@ func (r *Manager) GetAllHosts(service, portName string) []string {
 	return r.getEndpoints(service).getAllHosts(portName)
 }
 
-func (r *Manager) RegisterInFlight(ctx context.Context, service string, hostAddr string) (context.Context, func(), error) {
-	ctx, cancel := context.WithCancel(ctx)
-	completed, err := r.getEndpoints(service).AddInflight(hostAddr, cancel)
-	return ctx, completed, err
+func (r *Manager) RegisterInFlight(service string, hostAddr string) (func(), error) {
+	return r.getEndpoints(service).AddInflight(hostAddr)
 }

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -123,22 +123,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	newReverseProxy(host).ServeHTTP(w, proxyRequest)
 }
 
-func withInflightCounted(endpoints *endpoints.Manager, deploy string, host string) func(other http.Handler) http.HandlerFunc {
-	return func(other http.Handler) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			done, err := endpoints.RegisterInFlight(deploy, host)
-			if err != nil {
-				log.Printf("error registering in-flight request: %v", err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			defer done()
-
-			other.ServeHTTP(w, r)
-		}
-	}
-}
-
 // parseModel parses the model name from the request
 // returns empty string when none found or an error for failures on the proxy request object
 func parseModel(r *http.Request) (string, *http.Request, error) {

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -39,7 +39,7 @@ func NewHandler(deployments deploymentSource, endpoints *endpoints.Manager, queu
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var modelName string
-	captureStatusRespWriter := newCaptureStatusCodeResponseWriter(w)
+	captureStatusRespWriter := NewCaptureStatusCodeResponseWriter(w)
 	w = captureStatusRespWriter
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 		httpDuration.WithLabelValues(modelName, strconv.Itoa(captureStatusRespWriter.CapturedStatusCode())).Observe(v)
@@ -130,9 +130,9 @@ func parseModel(r *http.Request) (string, *http.Request, error) {
 		return model, r, nil
 	}
 	var body []byte
-	if mb, ok := r.Body.(*lazyBodyCapturer); ok && mb.capturedBody != nil {
+	if mb, ok := r.Body.(CapturedBodySource); ok && mb.IsCaptured() {
 		// reuse buffer
-		body = mb.capturedBody
+		body = mb.GetBody()
 	} else {
 		// parse request body for model name, ignore errors
 		var err error

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -129,10 +129,16 @@ func parseModel(r *http.Request) (string, *http.Request, error) {
 	if model := r.Header.Get("X-Model"); model != "" {
 		return model, r, nil
 	}
-	// parse request body for model name, ignore errors
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return "", r, nil
+	var body []byte
+	if mb, ok := r.Body.(*lazyBodyCapturer); ok && mb.capturedBody != nil {
+		body = mb.capturedBody
+	} else {
+		// parse request body for model name, ignore errors
+		var err error
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			return "", r, nil
+		}
 	}
 
 	var payload struct {

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -42,7 +42,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	captureStatusRespWriter := newCaptureStatusCodeResponseWriter(w)
 	w = captureStatusRespWriter
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		httpDuration.WithLabelValues(modelName, strconv.Itoa(captureStatusRespWriter.statusCode)).Observe(v)
+		httpDuration.WithLabelValues(modelName, strconv.Itoa(captureStatusRespWriter.CapturedStatusCode())).Observe(v)
 	}))
 	defer timer.ObserveDuration()
 

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -131,6 +131,7 @@ func parseModel(r *http.Request) (string, *http.Request, error) {
 	}
 	var body []byte
 	if mb, ok := r.Body.(*lazyBodyCapturer); ok && mb.capturedBody != nil {
+		// reuse buffer
 		body = mb.capturedBody
 	} else {
 		// parse request body for model name, ignore errors

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/substratusai/lingo/pkg/endpoints"
+	"github.com/substratusai/lingo/pkg/queue"
+)
+
+func TestProxy(t *testing.T) {
+	specs := map[string]struct {
+		request *http.Request
+		expCode int
+	}{
+		"ok": {
+			request: httptest.NewRequest(http.MethodGet, "/", strings.NewReader(`{"model":"my_model"}`)),
+			expCode: http.StatusBadGateway,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			deplMgr := mockDeploymentSource{
+				ResolveDeploymentFn: func(model string) (string, bool) {
+					return "my-deployment", true
+				},
+				AtLeastOneFn: func(deploymentName string) {},
+			}
+			em, err := endpoints.NewManager(&fakeManager{}, func(deploymentName string, replicas int) {})
+			require.NoError(t, err)
+			em.SetEndpoints("my-deployment", map[string]struct{}{"my-ip": {}}, map[string]int32{"my-port": 8080})
+			h := NewHandler(deplMgr, em, queue.NewManager(10))
+
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				em.SetEndpoints("my-deployment", map[string]struct{}{"my-other-ip": {}}, map[string]int32{"my-other-port": 8080})
+				time.Sleep(time.Millisecond)
+				w.WriteHeader(999)
+			}))
+			recorder := httptest.NewRecorder()
+
+			AdditionalProxyRewrite = func(r *httputil.ProxyRequest) {
+				r.SetURL(&url.URL{Scheme: "http", Host: svr.Listener.Addr().String()})
+			}
+
+			// when
+			// newCtx, cancel := context.WithCancel(spec.request.Context())
+			// cancel()
+			// newCtx, _ := context.WithTimeout(spec.request.Context(), time.Nanosecond)
+			newCtx := context.Background()
+
+			h.ServeHTTP(recorder, spec.request.Clone(newCtx))
+			// then
+			assert.Equal(t, spec.expCode, recorder.Code)
+		})
+	}
+}
+
+type mockDeploymentSource struct {
+	ResolveDeploymentFn func(model string) (string, bool)
+	AtLeastOneFn        func(deploymentName string)
+}
+
+func (m mockDeploymentSource) ResolveDeployment(model string) (string, bool) {
+	if m.ResolveDeploymentFn == nil {
+		panic("not expected to be called")
+	}
+	return m.ResolveDeploymentFn(model)
+}
+
+func (m mockDeploymentSource) AtLeastOne(deploymentName string) {
+	if m.AtLeastOneFn == nil {
+		panic("not expected to be called")
+	}
+	m.AtLeastOneFn(deploymentName)
+}

--- a/pkg/proxy/metrics.go
+++ b/pkg/proxy/metrics.go
@@ -22,21 +22,21 @@ func MustRegister(r prometheus.Registerer) {
 	r.MustRegister(httpDuration, totalRetries)
 }
 
-// statusCodeCapturer is an interface that extends the http.ResponseWriter interface and provides a method for reading the status code of an HTTP response.
-type statusCodeCapturer interface {
+// CaptureStatusCodeResponseWriter is an interface that extends the http.ResponseWriter interface and provides a method for reading the status code of an HTTP response.
+type CaptureStatusCodeResponseWriter interface {
 	http.ResponseWriter
-	CapturedStatusCode() int
+	StatusCodeCapturer
 }
 
-// captureStatusResponseWriter is a custom HTTP response writer that implements statusCodeCapturer
+// captureStatusResponseWriter is a custom HTTP response writer that implements CaptureStatusCodeResponseWriter
 type captureStatusResponseWriter struct {
 	http.ResponseWriter
 	statusCode  int
 	wroteHeader bool
 }
 
-func newCaptureStatusCodeResponseWriter(responseWriter http.ResponseWriter) statusCodeCapturer {
-	if o, ok := responseWriter.(statusCodeCapturer); ok { // nothing to do as code is captured already
+func NewCaptureStatusCodeResponseWriter(responseWriter http.ResponseWriter) CaptureStatusCodeResponseWriter {
+	if o, ok := responseWriter.(CaptureStatusCodeResponseWriter); ok { // nothing to do as code is captured already
 		return o
 	}
 	c := &captureStatusResponseWriter{ResponseWriter: responseWriter}

--- a/pkg/proxy/metrics.go
+++ b/pkg/proxy/metrics.go
@@ -12,8 +12,13 @@ var httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Buckets: prometheus.DefBuckets,
 }, []string{"model", "status_code"})
 
+var totalRetries = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "http_request_retry_total",
+	Help: "Number of HTTP request retries.",
+})
+
 func MustRegister(r prometheus.Registerer) {
-	r.MustRegister(httpDuration)
+	r.MustRegister(httpDuration, totalRetries)
 }
 
 // captureStatusResponseWriter is a custom HTTP response writer that captures the status code.

--- a/pkg/proxy/metrics_test.go
+++ b/pkg/proxy/metrics_test.go
@@ -65,10 +65,11 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, spec.expCode, recorder.Code)
 			gathered, err := registry.Gather()
 			require.NoError(t, err)
-			require.Len(t, gathered, 1)
-			require.Len(t, gathered[0].Metric, 1)
-			assert.NotEmpty(t, gathered[0].Metric[0].GetHistogram().GetSampleCount())
-			assert.Equal(t, spec.expLabels, toMap(gathered[0].Metric[0].Label))
+			require.Len(t, gathered, 2)
+			require.Equal(t, "http_response_time_seconds", *gathered[1].Name)
+			require.Len(t, gathered[1].Metric, 1)
+			assert.NotEmpty(t, gathered[1].Metric[0].GetHistogram().GetSampleCount())
+			assert.Equal(t, spec.expLabels, toMap(gathered[1].Metric[0].Label))
 		})
 	}
 }

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -14,7 +14,6 @@ var _ http.Handler = &RetryMiddleware{}
 type RetryMiddleware struct {
 	nextHandler      http.Handler
 	maxRetries       int
-	rSource          *rand.Rand
 	retryStatusCodes map[int]struct{}
 }
 
@@ -39,7 +38,6 @@ func NewRetryMiddleware(maxRetries int, other http.Handler, optRetryStatusCodes 
 		nextHandler:      other,
 		maxRetries:       maxRetries,
 		retryStatusCodes: statusCodeIndex,
-		rSource:          rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -72,7 +70,7 @@ func (r RetryMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 		totalRetries.Inc()
 		// exponential backoff
-		jitter := time.Duration(r.rSource.Intn(50))
+		jitter := time.Duration(rand.Intn(50))
 		time.Sleep(time.Millisecond*time.Duration(1<<uint(i)) + jitter)
 	}
 }

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"bytes"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+var _ http.Handler = &RetryMiddleware{}
+
+type RetryMiddleware struct {
+	other      http.Handler
+	MaxRetries int
+	rSource    *rand.Rand
+}
+
+func NewRetryMiddleware(maxRetries int, other http.Handler) *RetryMiddleware {
+	if maxRetries < 1 {
+		panic("invalid retries")
+	}
+	return &RetryMiddleware{
+		other:      other,
+		MaxRetries: maxRetries,
+		rSource:    rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (r RetryMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	var capturedResp *responseBuffer
+	for i := 0; ; i++ {
+		capturedResp = &responseBuffer{
+			header: make(http.Header),
+			body:   bytes.NewBuffer([]byte{}),
+		}
+		// call next handler in chain
+		r.other.ServeHTTP(capturedResp, request.Clone(request.Context()))
+
+		if i == r.MaxRetries || // max retries reached
+			request.Context().Err() != nil || // abort early on timeout, context cancel
+			capturedResp.status != http.StatusBadGateway &&
+				capturedResp.status != http.StatusServiceUnavailable {
+			break
+		}
+		totalRetries.Inc()
+		// Exponential backoff
+		jitter := time.Duration(r.rSource.Intn(50))
+		time.Sleep(time.Millisecond*time.Duration(1<<uint(i)) + jitter)
+	}
+	for k, v := range capturedResp.header {
+		writer.Header()[k] = v
+	}
+	writer.WriteHeader(capturedResp.status)
+	if _, err := capturedResp.body.WriteTo(writer); err != nil {
+		log.Printf("response write: %v", err)
+	}
+}
+
+type responseBuffer struct {
+	header http.Header
+	body   *bytes.Buffer
+	status int
+}
+
+func (rb *responseBuffer) Header() http.Header {
+	return rb.header
+}
+
+func (r *responseBuffer) WriteHeader(status int) {
+	r.status = status
+	r.header = r.Header().Clone()
+}
+
+func (rb *responseBuffer) Write(data []byte) (int, error) {
+	return rb.body.Write(data)
+}

--- a/pkg/proxy/middleware.go
+++ b/pkg/proxy/middleware.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"log"
 	"math/rand"
 	"net/http"
 	"time"
@@ -60,7 +61,9 @@ func (r RetryMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		// call next handler in chain
 		req, err := http.NewRequestWithContext(request.Context(), request.Method, request.URL.String(), lazyBody)
 		if err != nil {
-			panic(err)
+			log.Printf("clone request: %v", err)
+			writer.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 		r.nextHandler.ServeHTTP(capturedResp, req)
 		lazyBody.Capture()

--- a/pkg/proxy/middleware_test.go
+++ b/pkg/proxy/middleware_test.go
@@ -130,7 +130,7 @@ func TestWriteDelegatorReadFrom(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(myTestContent), int(n))
 	assert.Equal(t, myTestContent, rec.Body.String())
-	assert.Equal(t, http.StatusOK, d.capturedStatusCode())
+	assert.Equal(t, http.StatusOK, d.CapturedStatusCode())
 
 	// scenario: discard on error enabled
 	rec = &testResponseWriter{ResponseRecorder: httptest.NewRecorder()}
@@ -142,7 +142,7 @@ func TestWriteDelegatorReadFrom(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(myTestContent), int(n))
 	assert.Equal(t, "", rec.Body.String())
-	assert.Equal(t, http.StatusOK, d.capturedStatusCode())
+	assert.Equal(t, http.StatusOK, d.CapturedStatusCode())
 
 	// scenario: not implementing io.ReaderFrom
 	d = newResponseWriterDelegator(httptest.NewRecorder(), func(int) bool { return true }, false)

--- a/pkg/proxy/middleware_test.go
+++ b/pkg/proxy/middleware_test.go
@@ -1,9 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,38 +16,45 @@ import (
 )
 
 func TestServeHTTP(t *testing.T) {
+	myHeader := map[string][]string{"Foo": {"bar1", "bar2"}}
 	specs := map[string]struct {
 		context    func() context.Context
 		maxRetries int
+		headers    http.Header
 		respStatus int
 		expRetries int
 	}{
 		"no retry on 200": {
 			context:    func() context.Context { return context.TODO() },
+			headers:    myHeader,
 			maxRetries: 3,
 			respStatus: http.StatusOK,
 			expRetries: 0,
 		},
 		"no retry on 500": {
 			context:    func() context.Context { return context.TODO() },
+			headers:    myHeader,
 			maxRetries: 3,
 			respStatus: http.StatusInternalServerError,
 			expRetries: 0,
 		},
 		"max retries on 503": {
 			context:    func() context.Context { return context.TODO() },
+			headers:    myHeader,
 			maxRetries: 3,
 			respStatus: http.StatusServiceUnavailable,
 			expRetries: 3,
 		},
 		"max retries on 502": {
 			context:    func() context.Context { return context.TODO() },
+			headers:    myHeader,
 			maxRetries: 3,
 			respStatus: http.StatusBadGateway,
 			expRetries: 3,
 		},
 		"not buffered on 100": {
 			context:    func() context.Context { return context.TODO() },
+			headers:    myHeader,
 			maxRetries: 3,
 			respStatus: http.StatusContinue,
 			expRetries: 0,
@@ -54,6 +65,7 @@ func TestServeHTTP(t *testing.T) {
 				cancel()
 				return ctx
 			},
+			headers:    myHeader,
 			maxRetries: 3,
 			respStatus: http.StatusBadGateway,
 			expRetries: 0,
@@ -62,29 +74,104 @@ func TestServeHTTP(t *testing.T) {
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			counterBefore := counterValue(t, totalRetries)
-			req, err := http.NewRequestWithContext(spec.context(), "GET", "/test", nil)
+			const myBody = "my-request-body"
+			req, err := http.NewRequestWithContext(spec.context(), "GET", "/test", strings.NewReader(myBody))
 			require.NoError(t, err)
+			req.Header = spec.headers.Clone()
 
 			respRecorder := httptest.NewRecorder()
 
 			var counter int
-			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			testBackend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				counter++
+				// return all headers
+				for k, vals := range r.Header {
+					for _, v := range vals {
+						w.Header().Add(k, v)
+					}
+				}
 				w.WriteHeader(spec.respStatus)
+				reqBody, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				_, err = w.Write(append(reqBody, []byte(strconv.Itoa(spec.respStatus))...))
+				require.NoError(t, err)
 			})
 
 			// when
-			middleware := NewRetryMiddleware(spec.maxRetries, testHandler)
+			middleware := NewRetryMiddleware(spec.maxRetries, testBackend)
 			middleware.ServeHTTP(respRecorder, req)
 
 			// then
 			resp := respRecorder.Result()
 			require.Equal(t, spec.respStatus, resp.StatusCode)
 			assert.Equal(t, spec.expRetries, counter-1)
-
+			// and headers matches
+			assert.Equal(t, spec.headers, resp.Header)
+			// and body matches
+			bodyRead, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			assert.Equal(t, myBody+strconv.Itoa(spec.respStatus), string(bodyRead))
+			// and prometheus metric updated
 			assert.Equal(t, spec.expRetries, int(counterValue(t, totalRetries)-counterBefore))
 		})
 	}
+}
+
+func TestWriteDelegatorReadFrom(t *testing.T) {
+	const myTestContent = `my body content`
+
+	rec := &testResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	// scenario: discard on error disabled
+	d := newResponseWriterDelegator(rec, func(int) bool { return true }, false)
+	// when
+	n, err := d.(io.ReaderFrom).ReadFrom(strings.NewReader(myTestContent))
+	// then the content is written
+	require.NoError(t, err)
+	assert.Equal(t, len(myTestContent), int(n))
+	assert.Equal(t, myTestContent, rec.Body.String())
+	assert.Equal(t, http.StatusOK, d.capturedStatusCode())
+
+	// scenario: discard on error enabled
+	rec = &testResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	// with discard on error disabled
+	d = newResponseWriterDelegator(rec, func(int) bool { return true }, true)
+	// when
+	n, err = d.(io.ReaderFrom).ReadFrom(strings.NewReader(myTestContent))
+	// then the content is not written
+	require.NoError(t, err)
+	assert.Equal(t, len(myTestContent), int(n))
+	assert.Equal(t, "", rec.Body.String())
+	assert.Equal(t, http.StatusOK, d.capturedStatusCode())
+
+	// scenario: not implementing io.ReaderFrom
+	d = newResponseWriterDelegator(httptest.NewRecorder(), func(int) bool { return true }, false)
+	_, ok := d.(io.ReaderFrom)
+	require.False(t, ok)
+}
+
+func TestLazyBodyCapturer(t *testing.T) {
+	const myTestContent = "my-test-content"
+	c := newLazyBodyCapturer(io.NopCloser(strings.NewReader(myTestContent)))
+	var buf bytes.Buffer
+	n, err := c.(io.WriterTo).WriteTo(&buf)
+	require.NoError(t, err)
+	assert.Len(t, myTestContent, int(n))
+	assert.Equal(t, myTestContent, buf.String())
+	// when captured
+	c.Capture()
+	// then data is buffered for second read
+	buf.Reset()
+	n, err = c.(io.WriterTo).WriteTo(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, len(myTestContent), 15)
+	assert.Equal(t, myTestContent, buf.String())
+
+	// scenario: source reader does not implement WriteTo
+	c = newLazyBodyCapturer(testReader{strings.NewReader(myTestContent)})
+	// then instance also does not implement it
+	_, ok := c.(io.WriterTo)
+	require.False(t, ok)
 }
 
 func counterValue(t *testing.T, counter prometheus.Counter) float64 {
@@ -95,4 +182,24 @@ func counterValue(t *testing.T, counter prometheus.Counter) float64 {
 	require.Len(t, gathered, 1)
 	require.Len(t, gathered[0].Metric, 1)
 	return gathered[0].Metric[0].GetCounter().GetValue()
+}
+
+type testResponseWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (r *testResponseWriter) ReadFrom(re io.Reader) (int64, error) {
+	return r.ResponseRecorder.Body.ReadFrom(re)
+}
+
+type testReader struct {
+	r io.Reader
+}
+
+func (t testReader) Read(p []byte) (n int, err error) {
+	return t.r.Read(p)
+}
+
+func (t testReader) Close() error {
+	return nil
 }

--- a/pkg/proxy/middleware_test.go
+++ b/pkg/proxy/middleware_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeHTTP(t *testing.T) {
+	specs := map[string]struct {
+		context    func() context.Context
+		maxRetries int
+		respStatus int
+		expRetries int
+	}{
+		"no retry on 200": {
+			context:    func() context.Context { return context.TODO() },
+			maxRetries: 3,
+			respStatus: http.StatusOK,
+			expRetries: 0,
+		},
+		"no retry on 500": {
+			context:    func() context.Context { return context.TODO() },
+			maxRetries: 3,
+			respStatus: http.StatusInternalServerError,
+			expRetries: 0,
+		},
+		"max retries on 503": {
+			context:    func() context.Context { return context.TODO() },
+			maxRetries: 3,
+			respStatus: http.StatusServiceUnavailable,
+			expRetries: 3,
+		},
+		"max retries on 502": {
+			context:    func() context.Context { return context.TODO() },
+			maxRetries: 3,
+			respStatus: http.StatusBadGateway,
+			expRetries: 3,
+		},
+		"context cancelled": {
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.TODO())
+				cancel()
+				return ctx
+			},
+			maxRetries: 3,
+			respStatus: http.StatusBadGateway,
+			expRetries: 0,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			counterBefore := counterValue(t, totalRetries)
+			req, err := http.NewRequestWithContext(spec.context(), "GET", "/test", nil)
+			require.NoError(t, err)
+
+			respRecorder := httptest.NewRecorder()
+
+			var counter int
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				counter++
+				w.WriteHeader(spec.respStatus)
+			})
+
+			// when
+			middleware := NewRetryMiddleware(spec.maxRetries, testHandler)
+			middleware.ServeHTTP(respRecorder, req)
+
+			// then
+			resp := respRecorder.Result()
+			require.Equal(t, spec.respStatus, resp.StatusCode)
+			assert.Equal(t, spec.expRetries, counter-1)
+
+			assert.Equal(t, spec.expRetries, int(counterValue(t, totalRetries)-counterBefore))
+		})
+	}
+}
+
+func counterValue(t *testing.T, counter prometheus.Counter) float64 {
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(counter)
+	gathered, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, gathered, 1)
+	require.Len(t, gathered[0].Metric, 1)
+	return gathered[0].Metric[0].GetCounter().GetValue()
+}

--- a/pkg/proxy/middleware_test.go
+++ b/pkg/proxy/middleware_test.go
@@ -42,6 +42,12 @@ func TestServeHTTP(t *testing.T) {
 			respStatus: http.StatusBadGateway,
 			expRetries: 3,
 		},
+		"not buffered on 100": {
+			context:    func() context.Context { return context.TODO() },
+			maxRetries: 3,
+			respStatus: http.StatusContinue,
+			expRetries: 0,
+		},
 		"context cancelled": {
 			context: func() context.Context {
 				ctx, cancel := context.WithCancel(context.TODO())

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -229,6 +229,7 @@ func sendRequest(t *testing.T, wg *sync.WaitGroup, modelName string, expCode int
 	bodyRespChan := make(chan string, 1)
 	go func() {
 		defer wg.Done()
+		defer close(bodyRespChan)
 
 		body := []byte(fmt.Sprintf(`{"model": %q}`, modelName))
 		req, err := http.NewRequest(http.MethodPost, testServer.URL, bytes.NewReader(body))
@@ -241,7 +242,6 @@ func sendRequest(t *testing.T, wg *sync.WaitGroup, modelName string, expCode int
 		_ = res.Body.Close()
 		require.NoError(t, err)
 		bodyRespChan <- string(got)
-		close(bodyRespChan)
 	}()
 	return bodyRespChan
 }

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -81,9 +81,8 @@ func TestMain(m *testing.M) {
 	const concurrencyPerReplica = 1
 	queueManager = queue.NewManager(concurrencyPerReplica)
 
-	endpointManager, err := endpoints.NewManager(mgr)
+	endpointManager, err := endpoints.NewManager(mgr, queueManager.UpdateQueueSizeForReplicas)
 	requireNoError(err)
-	endpointManager.EndpointSizeCallback = queueManager.UpdateQueueSizeForReplicas
 
 	deploymentManager, err := deployments.NewManager(mgr)
 	requireNoError(err)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 		Endpoints:   endpointManager,
 		Queues:      queueManager,
 	}
-	testServer = httptest.NewServer(handler)
+	testServer = httptest.NewServer(proxy.NewRetryMiddleware(3, handler))
 	defer testServer.Close()
 
 	go func() {


### PR DESCRIPTION

Resolves #48 


the implementation is based on 2 elements:
* server middleware to retry a failed request with http status code 502, 503, 504

not considered is a priority queue for retries

