### PR TITLE
Fix race condition in test

### DIFF
--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -39,9 +39,9 @@ func TestConcurrentAccess(t *testing.T) {
 			)
 
 			var startWg, doneWg sync.WaitGroup
+			startWg.Add(spec.readerCount + spec.writerCount)
+			doneWg.Add(spec.readerCount + spec.writerCount)
 			startTogether := func(n int, f func()) {
-				startWg.Add(n)
-				doneWg.Add(n)
 				for i := 0; i < n; i++ {
 					go func() {
 						startWg.Done()


### PR DESCRIPTION
Resolves #53

🤔 interesting. It was not causing any problems on my box. I was using Go go1.21.5 + go1.21.6 darwin/arm64.
Only when I added a `time.Sleep(time.Millisecond)` before the second `startTogether` call, I can reproduce the issue.
Sorry for this. 

I found a similar scenario on [stackoverflow](https://stackoverflow.com/questions/39800700/waitgroup-is-reused-before-previous-wait-has-returned) that helped to resolve the issue.



