### PR TITLE
Stop scale down timer

### DIFF
--- a/pkg/deployments/manager.go
+++ b/pkg/deployments/manager.go
@@ -115,6 +115,7 @@ func getModelsFromAnnotation(ann map[string]string) []string {
 }
 
 func (r *Manager) removeDeployment(req ctrl.Request) {
+	r.getScaler(req.Name).StopScaleDownTimer()
 	r.scalersMtx.Lock()
 	delete(r.scalers, req.Name)
 	r.scalersMtx.Unlock()

--- a/pkg/deployments/manager.go
+++ b/pkg/deployments/manager.go
@@ -115,7 +115,7 @@ func getModelsFromAnnotation(ann map[string]string) []string {
 }
 
 func (r *Manager) removeDeployment(req ctrl.Request) {
-	r.getScaler(req.Name).StopScaleDownTimer()
+	r.getScaler(req.Name).Stop()
 	r.scalersMtx.Lock()
 	delete(r.scalers, req.Name)
 	r.scalersMtx.Unlock()

--- a/pkg/deployments/scaler.go
+++ b/pkg/deployments/scaler.go
@@ -116,7 +116,8 @@ func (s *scaler) compareScales(current, desired int32) {
 	}
 }
 
-func (s *scaler) StopScaleDownTimer() {
+// Stop stops the scale down process for the scaler.
+func (s *scaler) Stop() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	if s.scaleDownTimer != nil {

--- a/pkg/deployments/scaler.go
+++ b/pkg/deployments/scaler.go
@@ -116,6 +116,15 @@ func (s *scaler) compareScales(current, desired int32) {
 	}
 }
 
+func (s *scaler) StopScaleDownTimer() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.scaleDownTimer != nil {
+		s.scaleDownTimer.Stop()
+	}
+	s.scaleDownStarted = false
+}
+
 type scale struct {
 	Current, Min, Max int32
 }


### PR DESCRIPTION
See: #67 

When a deployment is deleted on reconcile there may still be a scale down timer running that modifies k8s replica state later. With this PR, the timer is stopped.