### PR TITLE
[Do not merge] alternative approach to clear state when not leader anymore

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -71,6 +71,7 @@ func (r *Autoscaler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (a *Autoscaler) Start() {
+	a.LeaderElection.AfterOnStoppedLeading(a.Deployments.StopScalers)
 	for range time.Tick(a.Interval) {
 		if !a.LeaderElection.IsLeader.Load() {
 			log.Println("Not leader, doing nothing")

--- a/pkg/deployments/manager.go
+++ b/pkg/deployments/manager.go
@@ -230,6 +230,15 @@ func (r *Manager) ReadinessChecker(_ *http.Request) error {
 	return nil
 }
 
+// StopScalers stops all scheduled scale down processes and resets desired state
+func (r *Manager) StopScalers() {
+	r.scalersMtx.Lock()
+	defer r.scalersMtx.Unlock()
+	for _, s := range r.scalers {
+		s.Stop()
+	}
+}
+
 func getAnnotationInt32(ann map[string]string, key string, defaultValue int32) int32 {
 	if ann == nil {
 		return defaultValue

--- a/pkg/deployments/manager.go
+++ b/pkg/deployments/manager.go
@@ -115,6 +115,7 @@ func getModelsFromAnnotation(ann map[string]string) []string {
 }
 
 func (r *Manager) removeDeployment(req ctrl.Request) {
+	r.getScaler(req.Name).StopScaleDownTimer()
 	r.scalersMtx.Lock()
 	delete(r.scalers, req.Name)
 	r.scalersMtx.Unlock()

--- a/pkg/deployments/manager.go
+++ b/pkg/deployments/manager.go
@@ -115,7 +115,7 @@ func getModelsFromAnnotation(ann map[string]string) []string {
 }
 
 func (r *Manager) removeDeployment(req ctrl.Request) {
-	r.getScaler(req.Name).StopScaleDownTimer()
+	r.getScaler(req.Name).Stop()
 	r.scalersMtx.Lock()
 	delete(r.scalers, req.Name)
 	r.scalersMtx.Unlock()

--- a/pkg/deployments/scaler.go
+++ b/pkg/deployments/scaler.go
@@ -116,7 +116,8 @@ func (s *scaler) compareScales(current, desired int32) {
 	}
 }
 
-func (s *scaler) StopScaleDownTimer() {
+// Stop stops the scale down process for the scaler.
+func (s *scaler) Stop() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	if s.scaleDownTimer != nil {

--- a/pkg/deployments/scaler.go
+++ b/pkg/deployments/scaler.go
@@ -116,6 +116,15 @@ func (s *scaler) compareScales(current, desired int32) {
 	}
 }
 
+func (s *scaler) StopScaleDownTimer() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.scaleDownTimer != nil {
+		s.scaleDownTimer.Stop()
+	}
+	s.scaleDownStarted = false
+}
+
 type scale struct {
 	Current, Min, Max int32
 }


### PR DESCRIPTION
Based on #70 

The autoscaler registers a callback on the elector when to stop scalers when not leader anymore.
This PR also contains changes to the scaler from #74