### PR TITLE
messenger: improve concurrent handling

### DIFF
--- a/cmd/lingo/main.go
+++ b/cmd/lingo/main.go
@@ -81,7 +81,7 @@ func run() error {
 		// Examples:
 		//
 		// Google PubSub:		"gcppubsub://projects/my-project/subscriptions/my-subscription|gcppubsub://projects/myproject/topics/mytopic"
-		// with maxHanlders:	"gcppubsub://projects/my-project/subscriptions/my-subscription|gcppubsub://projects/myproject/topics/mytopic|1000"
+		// with maxHandlers:	"gcppubsub://projects/my-project/subscriptions/my-subscription|gcppubsub://projects/myproject/topics/mytopic|1000"
 		// Amazon SQS-to-SQS:	"awssqs://sqs.us-east-2.amazonaws.com/123456789012/myqueue1?region=us-east-2|awssqs://sqs.us-east-2.amazonaws.com/123456789012/myqueue2?region=us-east-2"
 		// Amazon SQS-to-SNS:	"awssqs://sqs.us-east-2.amazonaws.com/123456789012/myqueue1?region=us-east-2|awssns:///arn:aws:sns:us-east-2:123456789012:mytopic?region=us-east-2"
 		//  (NOTE: 3 slashes for SNS)

--- a/cmd/lingo/main.go
+++ b/cmd/lingo/main.go
@@ -74,10 +74,14 @@ func run() error {
 		// MessengerURLs is a list of (comma-separated) URLs to listen for requests and send responses on.
 		//
 		// Format: <request-subscription1>|<response-topic1>,<request-subscription2>|<response-topic2>,...
+		// You can optionally also specify the max number of handlers for each messenger URL pair.
+		// If not specified, the default is 1000.
+		// Format with setting max concurrency: <request-subscription1>|<response-topic1>|<max-handlers1>,
 		//
 		// Examples:
 		//
 		// Google PubSub:		"gcppubsub://projects/my-project/subscriptions/my-subscription|gcppubsub://projects/myproject/topics/mytopic"
+		// with maxHanlders:	"gcppubsub://projects/my-project/subscriptions/my-subscription|gcppubsub://projects/myproject/topics/mytopic|1000"
 		// Amazon SQS-to-SQS:	"awssqs://sqs.us-east-2.amazonaws.com/123456789012/myqueue1?region=us-east-2|awssqs://sqs.us-east-2.amazonaws.com/123456789012/myqueue2?region=us-east-2"
 		// Amazon SQS-to-SNS:	"awssqs://sqs.us-east-2.amazonaws.com/123456789012/myqueue1?region=us-east-2|awssns:///arn:aws:sns:us-east-2:123456789012:mytopic?region=us-east-2"
 		//  (NOTE: 3 slashes for SNS)

--- a/pkg/messenger/messager.go
+++ b/pkg/messenger/messager.go
@@ -36,6 +36,7 @@ func NewMessenger(
 	ctx context.Context,
 	requestsURL string,
 	responsesURL string,
+	maxHandlers int,
 	deployments DeploymentManager,
 	endpoints EndpointManager,
 	queues QueueManager,
@@ -58,7 +59,7 @@ func NewMessenger(
 		HTTPC:       httpClient,
 		requests:    requests,
 		responses:   responses,
-		MaxHandlers: 1000,
+		MaxHandlers: maxHandlers,
 	}, nil
 }
 

--- a/pkg/messenger/messager.go
+++ b/pkg/messenger/messager.go
@@ -9,8 +9,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"sync"
-	"time"
 
 	"gocloud.dev/pubsub"
 	_ "gocloud.dev/pubsub/awssnssqs"
@@ -30,9 +28,6 @@ type Messenger struct {
 
 	requests  *pubsub.Subscription
 	responses *pubsub.Topic
-
-	consecutiveErrorsMtx sync.RWMutex
-	consecutiveErrors    int
 }
 
 func NewMessenger(
@@ -75,29 +70,7 @@ func (m *Messenger) Start(ctx context.Context) error {
 
 		m.handleRequest(context.Background(), msg)
 
-		// Slow down a bit to avoid churning through messages and running
-		// up cloud costs PubSub & GPUs when no meaningful work is being done.
-		//
-		// Intended to mitigate cases such as:
-		// * Spontaneous failures that might creep up overnight.
-		//   (Slow and speed back up later)
-		// * Some request-generation job sending a million malformed requests into a topic.
-		//   (Slow until an admin can intervene)
-		if consecutiveErrors := m.getConsecutiveErrors(); consecutiveErrors > 0 {
-			wait := consecutiveErrBackoff(consecutiveErrors)
-			log.Printf("after %d consecutive errors, waiting %v before processing next message", consecutiveErrors, wait)
-			time.Sleep(wait)
-		}
 	}
-}
-
-func consecutiveErrBackoff(n int) time.Duration {
-	d := time.Duration(n) * time.Second
-	const maxBackoff = 3 * time.Minute
-	if d > maxBackoff {
-		return maxBackoff
-	}
-	return d
 }
 
 func (m *Messenger) handleRequest(ctx context.Context, msg *pubsub.Message) {
@@ -255,7 +228,6 @@ func (m *Messenger) sendResponse(req *request, body []byte, statusCode int) {
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
 		log.Println("Error marshalling response:", err)
-		m.addConsecutiveError()
 	}
 
 	if err := m.responses.Send(req.ctx, &pubsub.Message{
@@ -265,7 +237,6 @@ func (m *Messenger) sendResponse(req *request, body []byte, statusCode int) {
 		},
 	}); err != nil {
 		log.Printf("Error sending response for message %s: %v", req.msg.LoggableID, err)
-		m.addConsecutiveError()
 
 		// If a repsonse cant be sent, the message should be redelivered.
 		if req.msg.Nackable() {
@@ -275,14 +246,10 @@ func (m *Messenger) sendResponse(req *request, body []byte, statusCode int) {
 	}
 
 	log.Printf("Send response for message: %s", req.msg.LoggableID)
-	if statusCode < 300 {
-		m.resetConsecutiveErrors()
-	}
 	req.msg.Ack()
 }
 
 func (m *Messenger) jsonError(format string, args ...interface{}) []byte {
-	m.addConsecutiveError()
 
 	message := fmt.Sprintf(format, args...)
 	log.Println(message)
@@ -302,22 +269,4 @@ func (m *Messenger) jsonError(format string, args ...interface{}) []byte {
 		"message": %q
 	}
 }`, message))
-}
-
-func (m *Messenger) addConsecutiveError() {
-	m.consecutiveErrorsMtx.Lock()
-	defer m.consecutiveErrorsMtx.Unlock()
-	m.consecutiveErrors++
-}
-
-func (m *Messenger) resetConsecutiveErrors() {
-	m.consecutiveErrorsMtx.Lock()
-	defer m.consecutiveErrorsMtx.Unlock()
-	m.consecutiveErrors = 0
-}
-
-func (m *Messenger) getConsecutiveErrors() int {
-	m.consecutiveErrorsMtx.RLock()
-	defer m.consecutiveErrorsMtx.RUnlock()
-	return m.consecutiveErrors
 }

--- a/pkg/messenger/messager.go
+++ b/pkg/messenger/messager.go
@@ -26,6 +26,8 @@ type Messenger struct {
 
 	HTTPC *http.Client
 
+	MaxHandlers int
+
 	requests  *pubsub.Subscription
 	responses *pubsub.Topic
 }
@@ -56,10 +58,14 @@ func NewMessenger(
 		HTTPC:       httpClient,
 		requests:    requests,
 		responses:   responses,
+		MaxHandlers: 1000,
 	}, nil
 }
 
 func (m *Messenger) Start(ctx context.Context) error {
+	sem := make(chan struct{}, m.MaxHandlers)
+
+recvLoop:
 	for {
 		msg, err := m.requests.Receive(ctx)
 		if err != nil {
@@ -68,9 +74,28 @@ func (m *Messenger) Start(ctx context.Context) error {
 
 		log.Println("Received message:", msg.LoggableID)
 
-		m.handleRequest(context.Background(), msg)
+		// Wait if there are too many active handle goroutines and acquire the
+		// semaphore. If the context is canceled, stop waiting and start shutting
+		// down.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break recvLoop
+		}
 
+		go func() {
+			defer func() { <-sem }()
+			m.handleRequest(context.Background(), msg)
+		}()
 	}
+
+	// We're no longer receiving messages. Wait to finish handling any
+	// unacknowledged messages by totally acquiring the semaphore.
+	for n := 0; n < m.MaxHandlers; n++ {
+		sem <- struct{}{}
+	}
+
+	return nil
 }
 
 func (m *Messenger) handleRequest(ctx context.Context, msg *pubsub.Message) {
@@ -109,28 +134,24 @@ func (m *Messenger) handleRequest(ctx context.Context, msg *pubsub.Message) {
 	log.Printf("Entering queue: %s", msg.LoggableID)
 
 	complete := m.Queues.EnqueueAndWait(ctx, backendDeployment, msg.LoggableID)
+	defer complete()
 
 	log.Printf("Awaiting host for message %s", msg.LoggableID)
 
 	host, err := m.Endpoints.AwaitHostAddress(ctx, backendDeployment, "http")
 	if err != nil {
-		complete()
 		m.sendResponse(req, m.jsonError("error awaiting host for backend: %v", err), http.StatusBadGateway)
 		return
 	}
 
-	// Do work in a goroutine to avoid blocking the main loop.
-	go func() {
-		defer complete()
-		url := fmt.Sprintf("http://%s%s", host, req.path)
-		log.Printf("Sending request to backend for message %s: %s", msg.LoggableID, url)
-		respPayload, respCode, err := m.sendBackendRequest(ctx, url, req.body)
-		if err != nil {
-			m.sendResponse(req, m.jsonError("error sending request to backend: %v", err), http.StatusBadGateway)
-		}
+	url := fmt.Sprintf("http://%s%s", host, req.path)
+	log.Printf("Sending request to backend for message %s: %s", msg.LoggableID, url)
+	respPayload, respCode, err := m.sendBackendRequest(ctx, url, req.body)
+	if err != nil {
+		m.sendResponse(req, m.jsonError("error sending request to backend: %v", err), http.StatusBadGateway)
+	}
 
-		m.sendResponse(req, respPayload, respCode)
-	}()
+	m.sendResponse(req, respPayload, respCode)
 }
 
 func (m *Messenger) Stop(ctx context.Context) error {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -151,6 +151,7 @@ func TestMain(m *testing.M) {
 		testCtx,
 		memRequestsURL,
 		memResponsesURL,
+		1000,
 		deploymentManager,
 		endpointManager,
 		queueManager,


### PR DESCRIPTION
Messenger will now default to a 1000 concurrent handlers. You can optionally specify the concurrency handlers for each URL pair, e.g. like this: `gcppubsub://projects/my-project/subscriptions/my-subscription|gcppubsub://projects/myproject/topics/mytopic|1000`

The concurrency is needed because otherwise the EnqueueAndWait will block until scale up happens. This makes sure that the messenger logic reflects how HTTP logic behaves as well.

