### PR TITLE
Fix lingo crash due to EXACTLY_ONCE_ACKID_FAILURE

### DIFF
--- a/pkg/messenger/messager.go
+++ b/pkg/messenger/messager.go
@@ -78,6 +78,10 @@ recvLoop:
 	for {
 		msg, err := m.requests.Receive(ctx)
 		if err != nil {
+			if strings.Contains(err.Error(), "EXACTLY_ONCE_ACKID_FAILURE") {
+				// This error is expected when a message is redelivered. So skip it.
+				continue
+			}
 			return err
 		}
 


### PR DESCRIPTION
Fixes #100