### PR TITLE
fix autoscaler stats aggregation

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -131,7 +131,7 @@ func aggregateStats(s stats.Stats, httpc *http.Client, endpoints []string) (stat
 		}
 		for k, v := range fetched.ActiveRequests {
 			log.Printf("Aggregating active requests for endpoint: %v: %v: %v", endpoint, k, v)
-			s.ActiveRequests[k] = fetched.ActiveRequests[k] + v
+			s.ActiveRequests[k] += v
 		}
 	}
 


### PR DESCRIPTION
The stats were incorrectly being summed together. This was causing Lingo to not scale up as high as it should when there are multiple lingo replicas.