### PR TITLE
Revert "Fix lingo crash due to EXACTLY_ONCE_ACKID_FAILURE (#112)"

### DIFF
--- a/pkg/messenger/messager.go
+++ b/pkg/messenger/messager.go
@@ -78,10 +78,6 @@ recvLoop:
 	for {
 		msg, err := m.requests.Receive(ctx)
 		if err != nil {
-			if strings.Contains(err.Error(), "EXACTLY_ONCE_ACKID_FAILURE") {
-				// This error is expected when a message is redelivered. So skip it.
-				continue
-			}
 			return err
 		}
 


### PR DESCRIPTION
This reverts commit ce85de92d47034920ba02daa566187fecc61db15.

This causes hangs and requires a different approach to gracefully handle the failure. We should reopen the subscription in case there is any error on message receive